### PR TITLE
Displaying icon on the right of the text instead of left

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -249,7 +249,7 @@
 						</tr>
             <tr>
               <td><code>.rightarrow</code></td>
-              <td><a href="javascript:void(false)" class="button"><span class="rightarrow icon"></span>Move Right</a></td>
+              <td><a href="javascript:void(false)" class="button">Move Right<span class="rightarrow icon after"></span></a></td>
             </tr>
 						<tr>
 							<td><code>.rss</code></td>

--- a/stylesheets/css3buttons.css
+++ b/stylesheets/css3buttons.css
@@ -16,6 +16,7 @@ a.button.middle:active,
 a.button.right:active { top: 0px }
 a.button.big { font-size: 16px; padding: 7px 16px; }
 a.button span.icon { display: inline-block; width: 14px; height: 12px; margin: auto 7px auto auto; position: relative; top: 1px; background-image: url('../images/css3buttons_icons.png'); background-repeat: no-repeat; }
+a.button span.icon.after { margin: auto auto auto 7px; }
 a.big.button span.icon { top: 0px }
 a.button span.icon.book { background-position: 0 0 }
 a.button:hover span.icon.book { background-position: 0 -15px }


### PR DESCRIPTION
Added an "after" class. So when icon is to be displayed after the text, it will have left margin of 7px instead of right margin.
