### PR TITLE
Allowing for groups with zero or >2 .middle buttons

### DIFF
--- a/stylesheets/css3buttons.css
+++ b/stylesheets/css3buttons.css
@@ -16,8 +16,8 @@ a.button.positive:hover, button.positive:hover { background-position: 0 -280px; 
 a.button.positive:active, button.positive:active,
 a.button.positive.active, button.positive.active { background-position: 0 -320px; background-color: #45BF55; }
 a.button.pill, button.pill { -webkit-border-radius: 19px; -moz-border-radius: 19px; border-radius: 19px; padding: 5px 10px 4px 10px; *padding: 4px 10px; }
-a.button.left, button.left { -webkit-border-bottom-right-radius: 0px; -webkit-border-top-right-radius: 0px; -moz-border-radius-bottomright: 0px; -moz-border-radius-topright: 0px; border-bottom-right-radius: 0px; border-top-right-radius: 0px; margin-right: 0px; }
-a.button.middle, button.middle { margin-right: 0px; margin-left: 0px; -webkit-border-radius: 0px; -moz-border-radius: 0px; border-radius: 0px; border-right: none; border-left: none; }
+a.button.left, button.left { -webkit-border-bottom-right-radius: 0px; -webkit-border-top-right-radius: 0px; -moz-border-radius-bottomright: 0px; -moz-border-radius-topright: 0px; border-bottom-right-radius: 0px; border-top-right-radius: 0px; margin-right: 0px; border-right: none; }
+a.button.middle, button.middle { margin-right: 0px; margin-left: 0px; -webkit-border-radius: 0px; -moz-border-radius: 0px; border-radius: 0px; border-right: none; }
 a.button.right, button.right { -webkit-border-bottom-left-radius: 0px; -webkit-border-top-left-radius: 0px; -moz-border-radius-bottomleft: 0px; -moz-border-radius-topleft: 0px; border-top-left-radius: 0px; border-bottom-left-radius: 0px; margin-left: 0px; }
 a.button.left:active, button.left:active,
 a.button.middle:active, button.middle:active,


### PR DESCRIPTION
I adjusted styles so that two-button groups don't have a double border in between.

You used to have (basically) the following:

```
.left { }
.middle { border-left: none; border-right: none; }
.right { }
```

This wouldn't work if there were any number other than one `.middle`. It would result in double borders (`.left` then `.right`) or no borders at all (`.left` then `.middle` then `.middle` then `.right`).
