### PR TITLE
Change the way buttons are grouped to allow consistent borders

### DIFF
--- a/stylesheets/css3buttons.css
+++ b/stylesheets/css3buttons.css
@@ -1,9 +1,9 @@
-a.button, button { display: inline-block; padding: 6px 5px 5px 5px; font-family: 'lucida grande', tahoma, verdana, arial, sans-serif; font-size: 12px; color: #3C3C3D; text-shadow: 1px 1px 0 #FFFFFF; background: #ECECEC url('../images/css3buttons_backgrounds.png') 0 0 no-repeat; white-space: nowrap; overflow: visible; cursor: pointer; text-decoration: none; border: 1px solid #CACACA; -webkit-border-radius: 2px; -moz-border-radius: 2px; border-radius: 2px; outline: none; position: relative; zoom: 1; line-height: 1.11; *display: inline; *vertical-align: middle; }
+a.button, button { display: inline-block; padding: 6px 5px 5px 5px; font-family: 'lucida grande', tahoma, verdana, arial, sans-serif; font-size: 12px; color: #3C3C3D; text-shadow: 1px 1px 0 #FFFFFF; background: #ECECEC url('../images/css3buttons_backgrounds.png') 0 0 no-repeat; white-space: nowrap; overflow: visible; cursor: pointer; text-decoration: none; border: 1px solid #CACACA; -webkit-border-radius: 2px; -moz-border-radius: 2px; border-radius: 2px; outline: none; position: relative; zoom: 1; line-height: 1.11; z-index: 1; *display: inline; *vertical-align: middle; }
 button { margin-left: 0; margin-right: 0; *padding: 5px 5px 3px 5px; }
 button::-moz-focus-inner { border: 0; padding:0px; }
 a.button.primary, button.primary { font-weight: bold }
 a.button:focus, button:focus,
-a.button:hover, button:hover { color: #FFFFFF; border-color: #388AD4; text-decoration: none; text-shadow: -1px -1px 0 rgba(0,0,0,0.3); background-position: 0 -40px; background-color: #2D7DC5; }
+a.button:hover, button:hover { color: #FFFFFF; border-color: #388AD4; text-decoration: none; text-shadow: -1px -1px 0 rgba(0,0,0,0.3); background-position: 0 -40px; background-color: #2D7DC5; z-index: 2; }
 a.button:active, button:active,
 a.button.active, button.active { background-position: 0 -81px; border-color: #347BBA; background-color: #0F5EA2; color: #FFFFFF; text-shadow: none; }
 a.button:active, button:active { top: 1px }
@@ -16,8 +16,8 @@ a.button.positive:hover, button.positive:hover { background-position: 0 -280px; 
 a.button.positive:active, button.positive:active,
 a.button.positive.active, button.positive.active { background-position: 0 -320px; background-color: #45BF55; }
 a.button.pill, button.pill { -webkit-border-radius: 19px; -moz-border-radius: 19px; border-radius: 19px; padding: 5px 10px 4px 10px; *padding: 4px 10px; }
-a.button.left, button.left { -webkit-border-bottom-right-radius: 0px; -webkit-border-top-right-radius: 0px; -moz-border-radius-bottomright: 0px; -moz-border-radius-topright: 0px; border-bottom-right-radius: 0px; border-top-right-radius: 0px; margin-right: 0px; }
-a.button.middle, button.middle { margin-right: 0px; margin-left: 0px; -webkit-border-radius: 0px; -moz-border-radius: 0px; border-radius: 0px; border-right: none; border-left: none; }
+a.button.left, button.left { -webkit-border-bottom-right-radius: 0px; -webkit-border-top-right-radius: 0px; -moz-border-radius-bottomright: 0px; -moz-border-radius-topright: 0px; border-bottom-right-radius: 0px; border-top-right-radius: 0px; margin-right: -1px; }
+a.button.middle, button.middle { margin-right: -1px; margin-left: 0px; -webkit-border-radius: 0px; -moz-border-radius: 0px; border-radius: 0px; }
 a.button.right, button.right { -webkit-border-bottom-left-radius: 0px; -webkit-border-top-left-radius: 0px; -moz-border-radius-bottomleft: 0px; -moz-border-radius-topleft: 0px; border-top-left-radius: 0px; border-bottom-left-radius: 0px; margin-left: 0px; }
 a.button.left:active, button.left:active,
 a.button.middle:active, button.middle:active,


### PR DESCRIPTION
This is more of a suggestion really, as I haven't been able to perform browser tests beyond the latest Safari & Chrome, and Firefox 3.6. Someone with more knowledge of cross-browser CSS or access to other browsers may have more to say on this code :)

As some others have pointed out, grouped buttons work best with only one middle button -- with no middle button there is a double border in the middle, and with more than one middle button some borders are lost altogether. I also noticed that `.middle` buttons aren't given a left or right border, even on hover -- so even with only one middle button, it didn't look quite right to me. So this code aims to address that.

Basically I have experimented with overlapping each button by 1px, and using z-index to control which borders are shown.
- `.middle` buttons retain both the left and right border.
- `.left` and `.middle` buttons have `margin-right: -1px`
- all buttons have a z-index (in this case, "1", however it could be anything really)
- buttons in hover state have a +1 z-index (so in this case, "2")

The result is that all buttons have both left and right borders, but the 1px overlap addresses the resulting double borders. The z-index then ensures that the correct borders are shown on hover (otherwise one border would remain unchanged as it would be hidden beneath another button).

And finally, this allows any number of middle buttons (including none at all). The negative margin ensures that all borders are 1px regardless of how many buttons are in the group.

It seems to work well on Safari, Chrome and Firefox however as I say I haven't been able to perform more comprehensive browser tests.

Cheers :)
